### PR TITLE
Make processString honor exclude field in config

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -396,7 +396,7 @@ var Comb = function(predefinedOptions) {
         var context = options && options.context;
         var tree;
 
-        if (!text) return text;
+        if (!text || !_this.shouldProcessFile(filename)) return text;
 
         // TODO: Parse different syntaxes
         _this.syntax = syntax || 'css';


### PR DESCRIPTION
Atom's [atom-beautify](https://github.com/Glavin001/atom-beautify/blob/master/src/beautifiers/csscomb.coffee#L54) is using the method processString to call csscomb. This is a problem, because processString is not checking the exclude field in the config. That means that packages like atom-beautify, that have the option to call csscomb on save, or init scripts to call csscomb every time you write ";", are beautifying files that are in the exclude list. It has some nasty effects, like reordering mixins and functions, potentially breaking them or other problems.

I thought I would submit a pull request instead of opening a new issue, just in case this simple change is accepted.
I don't know if shouldProcessFile was not being called here by design, or if the parameter filename should be renamed to path. Tell me if there is anything that should be changed.

If it's accepted and the npm package is updated, I'll submit another patch to atom so it can use the new feature, since it's not using filename at the moment.
