### PR TITLE
Let define syntax for extensions; Fix #6

### DIFF
--- a/test/core.js
+++ b/test/core.js
@@ -38,6 +38,14 @@ describe('Core methods', function() {
       assert.deepEqual(comb.exclude, [minimatchedPattern]);
     });
 
+    it('should create syntax map', function() {
+      var config = {syntax: {'.css': 'scss'}};
+
+      comb.configure(config);
+      assert.equal(comb.syntaxMap.size, 1);
+      assert.equal(comb.syntaxMap.get('.css'), 'scss');
+    });
+
     it('should not configure plugins that have not been added', function() {
       var config = {animal: 'panda'};
       comb.configure(config);
@@ -95,6 +103,20 @@ describe('Core methods', function() {
             done();
           });
     });
+
+    it('should use syntax from config', function(done) {
+      comb.use(require('./helpers/plugin_syntax_map'))
+        .configure({
+          'syntax-map': true,
+          syntax: {
+            '.tcss': 'scss'
+          }
+        })
+        .lintFile(__dirname + '/helpers/scss.tcss')
+        .then(function() {
+          done();
+        });
+    })
   });
 
   describe('lintPath', function() {

--- a/test/helpers/plugin_syntax_map.js
+++ b/test/helpers/plugin_syntax_map.js
@@ -1,0 +1,12 @@
+module.exports = {
+  name: 'syntax-map',
+  syntax: ['scss'],
+  accepts: {
+    boolean: [true, false]
+  },
+  lint: function() {
+    return [{
+    }];
+  },
+  process: function() {}
+};

--- a/test/helpers/scss.tcss
+++ b/test/helpers/scss.tcss
@@ -1,0 +1,5 @@
+.foo {
+  .bar {
+    color: red;
+  }
+}


### PR DESCRIPTION
Discussion: #6 
In `.csscomb.json`:
```json
{
    "syntax": {
        ".css": "scss",
        ".lss": "less"
    }
}
```
If the implementation is ok, I’ll write tests.